### PR TITLE
wave2: increase limits.cpu

### DIFF
--- a/deployment/kubernetes/wave2.yaml.envsubst
+++ b/deployment/kubernetes/wave2.yaml.envsubst
@@ -45,7 +45,7 @@ items:
               resources:
                 limits:
                   memory: 200Mi
-                  cpu: 100m
+                  cpu: 1.0
                 requests:
                   memory: 75Mi
                   cpu: 40m


### PR DESCRIPTION
- from `100m` to `1.0`
  - based on recommendation from Evan in #releng

ref: REL-1074
