### PR TITLE
fix: increase memory limits

### DIFF
--- a/deployment/kubernetes/wave0.yaml.envsubst
+++ b/deployment/kubernetes/wave0.yaml.envsubst
@@ -44,7 +44,7 @@ items:
             - image: "quay.io/razee/remoteresource:${WAVE0_VERSION}"
               resources:
                 limits:
-                  memory: 200Mi
+                  memory: 500Mi
                   cpu: 1.0
                 requests:
                   memory: 75Mi

--- a/deployment/kubernetes/wave3.yaml.envsubst
+++ b/deployment/kubernetes/wave3.yaml.envsubst
@@ -44,7 +44,7 @@ items:
             - image: "quay.io/razee/remoteresource:${WAVE3_VERSION}"
               resources:
                 limits:
-                  memory: 200Mi
+                  memory: 500Mi
                   cpu: 1.0
                 requests:
                   memory: 75Mi

--- a/deployment/kubernetes/wave4.yaml.envsubst
+++ b/deployment/kubernetes/wave4.yaml.envsubst
@@ -44,7 +44,7 @@ items:
             - image: "quay.io/razee/remoteresource:${WAVE4_VERSION}"
               resources:
                 limits:
-                  memory: 200Mi
+                  memory: 500Mi
                   cpu: 1.0
                 requests:
                   memory: 75Mi

--- a/deployment/kubernetes/wave5.yaml.envsubst
+++ b/deployment/kubernetes/wave5.yaml.envsubst
@@ -44,7 +44,7 @@ items:
             - image: "quay.io/razee/remoteresource:${WAVE5_VERSION}"
               resources:
                 limits:
-                  memory: 200Mi
+                  memory: 500Mi
                   cpu: 1.0
                 requests:
                   memory: 75Mi


### PR DESCRIPTION
Memory limit was previously increased for waves1 and 2 but now
the wave4 pod is also OOMing so increasing all waves to same limit.
